### PR TITLE
feat: added transforming of atrules

### DIFF
--- a/src/__tests__/atRules.test.js
+++ b/src/__tests__/atRules.test.js
@@ -1,0 +1,111 @@
+var postcss = require('postcss');
+var plugin = require('..');
+
+function run(testMsg = 'should work', input, output) {
+  it(testMsg, (done) => {
+    let result = postcss([plugin.default()]).process(input, {
+      from: undefined,
+    });
+    expect(result.css).toEqual(output);
+    done();
+  });
+}
+
+describe('transforming @media', () => {
+  run(
+    'should safely transform the @media and its properties',
+    '@MEDIA screen and (min-width: 480px){body{COLOR: lightgreen;}}',
+    '@media screen and (min-width: 480px){body{color: lightgreen;}}'
+  );
+
+  run(
+    'should safely transform the @media but not the params',
+    '@MEDIA SCREEN and (min-width: 480px){}',
+    '@media SCREEN and (min-width: 480px){}'
+  );
+});
+
+describe('transforming @charset', () => {
+  run(
+    'should not transform the @charset',
+    '@charset "UTF-8";',
+    '@charset "UTF-8";'
+  );
+  run(
+    'should safely transform the @charset',
+    '@CHARSET "iso-8859-15";',
+    '@charset "iso-8859-15";'
+  );
+});
+
+describe('transforming @import ', () => {
+  run(
+    'should  transform the @import ',
+    `@IMPORT url("fineprint.css") print;@import url("bluish.css") speech;@ImPoRt 'custom.css';@import url("CHROME://communicator/SKIN/");@import "common.css" screen;`,
+    `@import url("fineprint.css") print;@import url("bluish.css") speech;@import 'custom.css';@import url("CHROME://communicator/SKIN/");@import "common.css" screen;`
+  );
+});
+
+describe('transforming @namespace', () => {
+  run(
+    'should safely transform the @namespace',
+    '@NAMESPACE prefix url(http://www.w3.org/1999/xhtml);',
+    '@namespace prefix url(http://www.w3.org/1999/xhtml);'
+  );
+});
+
+describe('transforming @supports ', () => {
+  run(
+    'should safely transform the @supports ',
+    '@SUPPORTS (display: grid) {div {display: grid;}};@supports not (display: GRID) {div {float: right;}}',
+    '@supports (display: grid) {div {display: grid;}};@supports not (display: GRID) {div {float: right;}}'
+  );
+});
+
+describe('transforming @document  ', () => {
+  run(
+    'should safely transform the @document  ',
+    '@DOCUMENT URL("https://www.EXAMPLE.com/") {h1 {COLOR: green;}}',
+    '@document URL("https://www.EXAMPLE.com/") {h1 {color: green;}}'
+  );
+});
+
+describe('transforming @page   ', () => {
+  run(
+    'should safely transform the @page   ',
+    '@PAGE {margin: 1cm;};@page :FIRST {margin: 2cm;}',
+    '@page {margin: 1cm;};@page :FIRST {margin: 2cm;}'
+  );
+});
+
+describe('transforming @font-face', () => {
+  run(
+    'should safely transform the @font-face   ',
+    '@FONT-FACE {font-family: "Open Sans";src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),url("/fonts/OpenSans-Regular-webfont.woff") FORMAT("woff");}',
+    '@font-face {font-family: "Open Sans";src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),url("/fonts/OpenSans-Regular-webfont.woff") FORMAT("woff");}'
+  );
+});
+
+describe('transforming @keyframes', () => {
+  run(
+    'should safely transform the @keyframes',
+    '@KEYFRAMES SLIDEIN {from {transform: translateX(0%);}};@KEYFRAMES important2  {FROM {TRANSFORM: translateX(0%);}}',
+    '@keyframes slidein {from {transform: translateX(0%);}};@keyframes important2  {from {transform: translateX(0%);}}'
+  );
+});
+
+describe('transforming @viewports', () => {
+  run(
+    'should safely transform the @viewports',
+    '@VIEWPORT {min-width: 640px;max-width: 800px;}@viewport {ZOOM: 0.75;  min-zoom: 0.5;max-zoom: 0.9;}@viewport {orientation: LANDSCAPE;}',
+    '@viewport {min-width: 640px;max-width: 800px;}@viewport {zoom: 0.75;  min-zoom: 0.5;max-zoom: 0.9;}@viewport {orientation: LANDSCAPE;}'
+  );
+});
+
+describe('transforming @counter-style', () => {
+  run(
+    'should safely transform the @counter-style',
+    '@counter-STYLE thumbs {system: cyclic;SYMBOLs: "F44D";suffix: " ";} UL{list-style: THUMBS;}',
+    '@counter-style thumbs {system: cyclic;symbols: "F44D";suffix: " ";} ul{list-style: THUMBS;}'
+  );
+});

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -127,23 +127,3 @@ describe('transforming CSS units', () => {
     'p.low { pitch: 105hz; }'
   );
 });
-
-describe('transforming @rules', () => {
-  run(
-    'should safely transform the @media and its properties',
-    '@MEDIA screen and (min-width: 480px){body{COLOR: lightgreen;}}',
-    '@media screen and (min-width: 480px){body{color: lightgreen;}}'
-  );
-
-  run(
-    'should safely transform the @namespace',
-    '@NAMESPACE prefix url(http://www.w3.org/1999/xhtml);',
-    '@namespace prefix url(http://www.w3.org/1999/xhtml);'
-  );
-
-  run(
-    'should safely transform the @media but not the params',
-    '@MEDIA SCREEN and (min-width: 480px){}',
-    '@media SCREEN and (min-width: 480px){}'
-  );
-});

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -127,3 +127,23 @@ describe('transforming CSS units', () => {
     'p.low { pitch: 105hz; }'
   );
 });
+
+describe('transforming @rules', () => {
+  run(
+    'should safely transform the @media and its properties',
+    '@MEDIA screen and (min-width: 480px){body{COLOR: lightgreen;}}',
+    '@media screen and (min-width: 480px){body{color: lightgreen;}}'
+  );
+
+  run(
+    'should safely transform the @namespace',
+    '@NAMESPACE prefix url(http://www.w3.org/1999/xhtml);',
+    '@namespace prefix url(http://www.w3.org/1999/xhtml);'
+  );
+
+  run(
+    'should safely transform the @media but not the params',
+    '@MEDIA SCREEN and (min-width: 480px){}',
+    '@media SCREEN and (min-width: 480px){}'
+  );
+});

--- a/src/atRules.js
+++ b/src/atRules.js
@@ -1,21 +1,41 @@
 const nameTransformOnly = (rule) => {
   rule.name = rule.name.toLowerCase();
 };
+const paramsTransform = (rule) => {
+  rule.params = rule.params.toLowerCase();
+};
 
-const nameAndPropsTransform = (rule) => {
-  rule.name = rule.name.toLowerCase();
+const propsTransform = (rule) => {
   rule.walkDecls((node) => {
     node.prop = node.prop.toLowerCase();
   });
 };
+const nameAndPropsTransform = (rule) => {
+  nameTransformOnly(rule);
+  propsTransform(rule);
+};
+
+const nameAndparamsTransform = (rule) => {
+  nameTransformOnly(rule);
+  paramsTransform(rule);
+};
+
+const nameParamsPropsTransform = (rule) => {
+  nameTransformOnly(rule);
+  paramsTransform(rule);
+  propsTransform(rule);
+};
 
 module.exports = {
-  keyframes: nameTransformOnly,
-  'counter-style': nameAndPropsTransform,
+  keyframes: nameParamsPropsTransform,
+  'counter-style': nameParamsPropsTransform,
   namespace: nameTransformOnly,
   import: nameTransformOnly,
   'font-face': nameAndPropsTransform,
   page: nameAndPropsTransform,
   supports: nameAndPropsTransform, // params todo,
-  media: nameAndPropsTransform, // params todo
+  media: nameAndPropsTransform, // params todo,
+  charset: nameTransformOnly,
+  document: nameTransformOnly,
+  viewport: nameAndPropsTransform,
 };

--- a/src/atRules.js
+++ b/src/atRules.js
@@ -1,0 +1,21 @@
+const nameTransformOnly = (rule) => {
+  rule.name = rule.name.toLowerCase();
+};
+
+const nameAndPropsTransform = (rule) => {
+  rule.name = rule.name.toLowerCase();
+  rule.walkDecls((node) => {
+    node.prop = node.prop.toLowerCase();
+  });
+};
+
+module.exports = {
+  keyframes: nameTransformOnly,
+  'counter-style': nameAndPropsTransform,
+  namespace: nameTransformOnly,
+  import: nameTransformOnly,
+  'font-face': nameAndPropsTransform,
+  page: nameAndPropsTransform,
+  supports: nameAndPropsTransform, // params todo,
+  media: nameAndPropsTransform, // params todo
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import * as postcss from 'postcss';
 import { transformer as unitTransformer } from './units';
 import { transformer as selectorTransformer } from './selector';
+import atRulesTranformerMap from './atRules';
 
 export default postcss.plugin('postcss-lowercase-props-selectors', () => {
   return (css) => {
@@ -19,6 +20,13 @@ export default postcss.plugin('postcss-lowercase-props-selectors', () => {
         node.value = unitTransformer(node.value);
         return node;
       });
+    });
+    css.walkAtRules((rule) => {
+      const allowedTransformingTypes = Object.keys(atRulesTranformerMap);
+      const allowedTransformingTypeSet = new Set(allowedTransformingTypes);
+      if (allowedTransformingTypeSet.has(rule.name.toLowerCase())) {
+        atRulesTranformerMap[rule.name.toLowerCase()](rule);
+      }
     });
   };
 });


### PR DESCRIPTION
Added `@` rules transforming.
Currently transforming the rule name and declarations property.
The rules parameter are not transformed as of now cause of the nonavailability of a parser. May write a custom parser for it but need some look something before writing it.

## Transformation details

- [x] **@keyframes** Transform `name` , `params`, and `props` to lowercase
- [x] **@counter-style** Transform `name` , `params`, and `props` to lowercase
- [x] **@namespace** Transform `name` lowercase,
- [x] **@import** Transform `name`to lowercase,
- [x] **@font-face** Transform `name` and `props` to lowercase,
- [x] **@page** Transform `name` and `props` to lowercase
- [x] **@supports** Transform `name` and `props` to lowercase
- [x] **@media** Transform `name` and `props` to lowercase
- [x] **@charset** Transform `name` to lowercase,
- [x] **@document** Transform `name` to lowercase,
- [x] **@viewport** Transform `name` and `props` to lowercase,
